### PR TITLE
Show multiple upgrades when available

### DIFF
--- a/src/Item.lua
+++ b/src/Item.lua
@@ -447,11 +447,15 @@ function ItemModule:GetUpgrades(link)
     local dreanorValorUpgrade = self:GetDreanorValorUpgrade(itemLink);
 
     if(craftedBonus) then
-        return GenerateUpgrades(self.CraftingUpgradeMap, craftedBonus, itemLink, "bonus");
-    elseif(balefulBonus) then
-        return GenerateUpgrades(self.BalefulUpgradeMap, balefulBonus, itemLink, "bonus");
-    elseif(dreanorValorUpgrade) then
-        return GenerateUpgrades(self.DreanorValorUpgradeMap, dreanorValorUpgrade, itemLink, "upgrade");
+        upgrades = Utils.TableConcat(upgrades, GenerateUpgrades(self.CraftingUpgradeMap, craftedBonus, itemLink, "bonus"));
+    end
+
+    if(balefulBonus) then
+        upgrades = Utils.TableConcat(upgrades, GenerateUpgrades(self.BalefulUpgradeMap, balefulBonus, itemLink, "bonus"));
+    end
+
+    if(dreanorValorUpgrade) then
+        upgrades = Utils.TableConcat(upgrades, GenerateUpgrades(self.DreanorValorUpgradeMap, dreanorValorUpgrade, itemLink, "upgrade"));
     end
 
     return upgrades;

--- a/src/Utils.lua
+++ b/src/Utils.lua
@@ -16,6 +16,17 @@ Utils.SortedKeys = function(t, sortFunction)
     return keys;
 end;
 
+Utils.TableConcat = function(...)
+   local result = {}
+   for _, tbl in pairs({...}) do
+       for _, item in pairs(tbl) do
+           table.insert(result, item)
+       end
+   end
+
+   return result
+end
+
 Utils.OrderKeysBy = function(array, property)
     return Utils.SortedKeys(array, function(key1, key2)
         return array[key1][property] < array[key2][property];


### PR DESCRIPTION
Somehow the valor upgrades already use `Empowered Baleful` as a base (Expected to have to use an `Empowered Baleful` ItemLink)

![untitled](https://cloud.githubusercontent.com/assets/16323751/11896173/8673d66e-a584-11e5-8001-310b3ec0627f.png)

Implements #35 